### PR TITLE
Speed up average tick calculation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 RUN apt-get update && apt-get -y upgrade && \
     # install dependencies
-    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y cmake gcc-arm-none-eabi git libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib wget && \
+    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y cmake gcc-arm-none-eabi git libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib python3 wget && \
 
     # install pico SDK
     git clone https://github.com/raspberrypi/pico-sdk.git && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,12 @@
 FROM ubuntu:latest
 RUN apt-get update && apt-get -y upgrade && \
     # install dependencies
-    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y cmake && \
+    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y cmake gcc-arm-none-eabi git libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib wget && \
+
+    # install pico SDK
+    git clone https://github.com/raspberrypi/pico-sdk.git && \
+    mv pico-sdk /usr/local/bin/pico-sdk && \
 
     # clean up
     rm -rf /tmp/*
+ENV PICO_SDK_PATH=/usr/local/bin/pico-sdk

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,6 +5,9 @@ RUN apt-get update && apt-get -y upgrade && \
 
     # install pico SDK
     git clone https://github.com/raspberrypi/pico-sdk.git && \
+    cd pico-sdk && \
+    git submodule update --init && \
+    cd .. && \
     mv pico-sdk /usr/local/bin/pico-sdk && \
 
     # clean up

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,7 @@
-FROM alpine:latest
-RUN apk update && \
-    apk add bash cmake git
+FROM ubuntu:latest
+RUN apt-get update && apt-get -y upgrade && \
+    # install dependencies
+    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y cmake && \
+
+    # clean up
+    rm -rf /tmp/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:latest
+RUN apk update && \
+    apk add bash cmake

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,3 @@
 FROM alpine:latest
 RUN apk update && \
-    apk add bash cmake
+    apk add bash cmake git

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 RUN apt-get update && apt-get -y upgrade && \
     # install dependencies
-    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y cmake gcc-arm-none-eabi git libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib python3 wget && \
+    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y cmake g++ gcc-arm-none-eabi git libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib python3 wget && \
 
     # install pico SDK
     git clone https://github.com/raspberrypi/pico-sdk.git && \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+    "build": {
+      "dockerfile": "Dockerfile"
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ elf2uf2
 pioasm
 generated
 pico-sdk
+CSync.pio.h

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ _deps
 elf2uf2
 pioasm
 generated
+pico-sdk

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,16 @@
 build/
 .vscode/
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+elf2uf2
+pioasm
+generated

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ pioasm
 generated
 pico-sdk
 CSync.pio.h
+PicoSync.*

--- a/src/main.c
+++ b/src/main.c
@@ -19,15 +19,16 @@
 //Systick target for timing between pulses
 volatile int systickTarget = 0x00ffffff;
 volatile int timingArray[NUM_SAMPLES];
+volatile int timingArrayIndex = 0;
+volatile uint64_t timingArraySum = 0;
+volatile bool timingArrayFull = false;
+
 
 /** 
  * @brief Updates the timing array with a new sample.
  * @param sample The new timing sample to add to the array.
  */
 void updateTimingArraySample(int sample){
-    static int timingArrayIndex = 0;
-    static uint64_t timingArraySum = 0;
-    static bool timingArrayFull = false;
     timingArraySum += sample;                        // add sample's value to sum
     timingArraySum -= timingArray[timingArrayIndex]; // subtract overwritten value from sum
     timingArray[timingArrayIndex++] = sample;        // overwrite value with sample

--- a/src/main.c
+++ b/src/main.c
@@ -26,9 +26,14 @@ volatile int timingArray[NUM_SAMPLES];
  */
 void updateTimingArraySample(int sample){
     static int timingArrayIndex = 0;
-    timingArray[timingArrayIndex++] = sample;
+    static uint64_t timingArraySum = 0;
+    static bool timingArrayFull = false;
+    timingArraySum += sample;                        // add sample's value to sum
+    timingArraySum -= timingArray[timingArrayIndex]; // subtract overwritten value from sum
+    timingArray[timingArrayIndex++] = sample;        // overwrite value with sample
     if(timingArrayIndex == NUM_SAMPLES){
         timingArrayIndex = 0;
+        timingArrayFull = true;
     }
 }
 
@@ -37,11 +42,13 @@ void updateTimingArraySample(int sample){
  * @return The average timing value.
  */
 int getAverageTicksBetweenPulses(){
-    uint64_t sum = 0;
-    for(int i = 0; i < NUM_SAMPLES; i++){
-        sum += timingArray[i];
+    if(timingArrayFull) {
+        return timingArraySum / NUM_SAMPLES;
+    } else if(timingArrayIndex == 0) {
+        return 0;
+    } else {
+        return timingArraySum / timingArrayIndex;
     }
-    return sum / NUM_SAMPLES;
 }
 
 #define VSYNC_PRESENT true


### PR DESCRIPTION
Instead of recalculating the average tick from scratch, you can store the sum globally, and every time you get a new sample, you can just add the new sample and subtract the one it's replacing to update the sum in O(1). As a result, each average tick calculation should be constant-time

Note that I haven't tested this (I don't have anything), so this edit is just based on looking at the code. You'll want to test it to make sure I didn't accidentally break something